### PR TITLE
improved right shift 

### DIFF
--- a/cgra.py
+++ b/cgra.py
@@ -275,14 +275,8 @@ class PE:
         return c_int32(val1 << val2).value
 
     def srt( val1, val2 ):
-        interm_result = c_int32(val1 >> val2).value
-        if (interm_result > 0):
-            return c_int32(val1 >> val2).value
-        else:
-            max=0
-            for i in range(val2):
-                max += 2**(31-i)
-            return c_int32( interm_result - max).value
+        interm_result = c_int32(val1).value & 0xFFFFFFFF
+        return c_int32(interm_result >> val2).value
 
     def sra( val1, val2 ):
         return c_int32(val1 >> val2).value

--- a/cgra.py
+++ b/cgra.py
@@ -275,7 +275,14 @@ class PE:
         return c_int32(val1 << val2).value
 
     def srt( val1, val2 ):
-        return c_int32(val1 >> val2).value # ToDo: Fix this one
+        interm_result = c_int32(val1 >> val2).value
+        if (interm_result > 0):
+            return c_int32(val1 >> val2).value
+        else:
+            max=0
+            for i in range(val2):
+                max += 2**(31-i)
+            return c_int32( interm_result - max).value
 
     def sra( val1, val2 ):
         return c_int32(val1 >> val2).value


### PR DESCRIPTION
[](url)
![Screenshot 2023-09-20 114023](https://github.com/esl-epfl/ESL-CGRA-simulator/assets/95174185/ecec5720-751c-4a1c-a0dc-9da8a0e6b8b5)

Hi Juan, maybe I've figured out what is the problem. In general, Python represents int number as signed. Due to this, the arithmetic right shift is computed automatically. If we print with' bin' function, we might thinks that it is not performed the arithmetic right shift, instead it does; the difference is that the bin function print in sign and module format, and not in 2's complement. As consequence, the arithmetic right shift is performed automatically; however for the logic shift I've improved my previous version; here I simply take the unsigned number (by doing the & with 0xFFFFFFFF), and then perform the shift. Let me know if everything looks correct. Thank you