### PR TITLE
Fix #11: Branches performed mid-execution

### DIFF
--- a/cgra.py
+++ b/cgra.py
@@ -91,10 +91,11 @@ class CGRA:
         for r in range(N_ROWS):
             for c in range(N_COLS):
                 self.cells[r][c].update()
-        if PRINT_OUTS: print("Instr = ", self.cycles, "(",self.instr2exec,")")
+        instr2exec = self.instr2exec
+        if PRINT_OUTS: print("Instr = ", self.cycles, "(",instr2exec,")")
         for r in range(N_ROWS):
             for c in range(N_COLS):
-                op =  self.instrs[self.instr2exec].ops[r][c]
+                op =  self.instrs[instr2exec].ops[r][c]
                 b ,e = self.cells[r][c].exec( op )
                 if b != 0: self.instr2exec = b - 1 #To avoid more logic afterwards
                 if e != 0: self.exit = True
@@ -321,7 +322,7 @@ class PE:
 
     def bge( self,  val1, val2, branch ):
         self.flags['branch'] = branch if val1 >= val2 else self.flags['branch']
-    
+
     def blt( self,  val1, val2, branch ):
         self.flags['branch'] = branch if val1 < val2 else self.flags['branch']
 


### PR DESCRIPTION
Branches were performed mid execution because the same variable that was used to decide which instruction should each PE execute was being updated after each execution. 

The change involves only querying that variable before starting all executions. 

This should fix #11 