### PR TITLE
Added implementation for fxpmul function

### DIFF
--- a/src/cgra.py
+++ b/src/cgra.py
@@ -293,8 +293,7 @@ class PE:
         return c_int32( val1 * val2 ).value
 
     def fxpmul( val1, val2 ):
-        print("Better luck next time")
-        return 0
+        return c_int32((c_int64(val1).value * c_int64(val2).value) >> 15).value
 
     def slt( val1, val2 ):
         return c_int32(val1 << val2).value


### PR DESCRIPTION
This pull request adds the implementation for the `fxpmul` function, which was previously missing. 

The function now performs a fixed-point multiplication of two 64-bit integers, shifts the result right by 15 bits, and returns the result as a 32-bit integer. This change provides the required arithmetic operation for the function, improving its functionality.

Here is the new implementation:
```python
def fxpmul(val1, val2):
    return c_int32((c_int64(val1).value * c_int64(val2).value) >> 15).value
```